### PR TITLE
Skip windows arm64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,3 +18,6 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64

--- a/execenv/user_unix.go
+++ b/execenv/user_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package execenv

--- a/tasks/job/signal_unix.go
+++ b/tasks/job/signal_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package job


### PR DESCRIPTION
Recent versions of goreleaser can build for windows arm64 but
dobi's code doesn't support it.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>